### PR TITLE
fix(text_field): handle error state UI correctly

### DIFF
--- a/lib/src/components/molecules/text_field.dart
+++ b/lib/src/components/molecules/text_field.dart
@@ -112,7 +112,9 @@ class DSTextField extends StatelessWidget {
               labelError!,
               style: TextStyle(color: colorScheme.error.color),
             )
-          : null,
+          : state == DSTextFieldState.error
+              ? const SizedBox.shrink()
+              : null,
       // Default
       border: UnderlineInputBorder(
         borderSide: BorderSide(

--- a/lib/src/components/screens/phone_verification_screen/controller.dart
+++ b/lib/src/components/screens/phone_verification_screen/controller.dart
@@ -94,6 +94,7 @@ class _DSPhoneVerificationController
       value = (value as DSPhoneVerificationNumberFormState).copyWith(
         errorMessage: message,
         isLoading: false,
+        buttonSendOtpEnabled: false,
       );
     } else if (value is DSPhoneVerificationOtpFormState) {
       _otp = '';
@@ -101,6 +102,7 @@ class _DSPhoneVerificationController
         otp: _otp,
         errorMessage: message,
         isLoading: false,
+        buttonSendOtpEnabled: false,
       );
     }
   }
@@ -130,6 +132,7 @@ class _DSPhoneVerificationController
     if (value is DSPhoneVerificationNumberFormState) {
       value = (value as DSPhoneVerificationNumberFormState).copyWith(
         isLoading: true,
+        buttonSendOtpEnabled: false,
       );
     }
   }


### PR DESCRIPTION
Ensure the error state in DSTextField hides the label when no error message is present to avoid UI inconsistency. Additionally, disable the OTP button during loading and error states in the phone verification controller to prevent unintended user actions.